### PR TITLE
chore: add config and rules for pair programming agent

### DIFF
--- a/.aider.conf.yml
+++ b/.aider.conf.yml
@@ -1,0 +1,6 @@
+# Aider configuration file
+read:
+  - .windsurf/rules/agent-rules.md
+  - .pair-programming-rules.md
+
+git: false

--- a/.pair-programming-rules.md
+++ b/.pair-programming-rules.md
@@ -1,0 +1,7 @@
+# Pair Programming Rules
+
+- do not make git commits
+- pair program with the human developer with <https://github.com/remotemobprogramming/mob> framework
+- human developer will the only one who executes `mob done`
+- agent will execute `mob start` when coding starts
+- agent will execute `mob next` when coding is complete and ready for review

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,9 @@
 {
   "python.testing.pytestArgs": ["app"],
   "python.testing.unittestEnabled": false,
-  "python.testing.pytestEnabled": true
+  "python.testing.pytestEnabled": true,
+  "yaml.schemas": {
+    "": [".aider.conf.yml"]
+  },
+  "yaml.validate": false
 }

--- a/.windsurf/rules/agent-rules.md
+++ b/.windsurf/rules/agent-rules.md
@@ -1,3 +1,7 @@
+---
+trigger: always_on
+---
+
 # Design and Principles
 
 - Simple python template I am experimenting with around a set of overlapping concepts with a Fastapi implementation:


### PR DESCRIPTION
Add YAML schema and disable validation in VSCode settings to support
.aider.conf.yml. Introduce agent and pair programming rules to define
agent behavior during coding sessions using the remotemobprogramming
framework. Add aider configuration to read these rules and disable git
integration for the agent. These changes enable structured collaboration
between human and agent in pair programming workflows.